### PR TITLE
Point at localhost for vector tiles

### DIFF
--- a/mq-carto-style.tm2/project.yml
+++ b/mq-carto-style.tm2/project.yml
@@ -32,7 +32,7 @@ layers:
 maxzoom: 19
 minzoom: 0
 name: MQ Carto Style
-source: "http://mq-nms-render-vector-stg-la01.ihost.aol.com:8080/tiles/tile.json"
+source: "http://localhost:8080/tiles/tile.json"
 styles: 
   - base.mss
   - water.mss


### PR DESCRIPTION
We need to point somewhere even if it's being replaced by localconfig or similar, and localhost is a reasonable default.